### PR TITLE
mosaics ver 2.9.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: mosaics
 Type: Package
 Title: MOSAiCS (MOdel-based one and two Sample Analysis and Inference for ChIP-Seq)
-Version: 2.9.8
+Version: 2.9.9
 Depends: R (>= 3.0.0), methods, graphics, Rcpp
 Imports: MASS, splines, lattice, IRanges, GenomicRanges, GenomicAlignments, Rsamtools, GenomeInfoDb, S4Vectors
 Suggests: mosaicsExample
 Enhances: parallel
 LinkingTo: Rcpp
 SystemRequirements: Perl
-Date: 2016-01-31
+Date: 2016-03-15
 Author: Dongjun Chung, Pei Fen Kuan, Rene Welch, Sunduz Keles
 Maintainer: Dongjun Chung <dongjun.chung@gmail.com>
 Description: This package provides functions for fitting MOSAiCS and MOSAiCS-HMM, a statistical framework to analyze one-sample or two-sample ChIP-seq data of transcription factor binding and histone modification.

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,10 @@
+ 
+Changes in version 2.9.9:
 
+BUG FIXES
+
+    o generateWig(): fix the error specific to the BAM file format, which generated unnecessary lines in the output WIG file.
+	
 Changes in version 2.9.8:
 
 BUG FIXES

--- a/R/generateWig.R
+++ b/R/generateWig.R
@@ -137,6 +137,8 @@ generateWig <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
       
       # process chromosome by chromosome
       
+      printHeader <- FALSE
+      
       for ( chr in chrnames ) {
         
         # skip if in the list of excludeChr or not in the chrfile
@@ -209,8 +211,11 @@ generateWig <- function( infile=NULL, fileFormat=NULL, outfileLoc="./",
         
         # write bin-level data file
   	
-    		cat( 'track type=wiggle_0 name="',outfile,'" ', file=outfile, sep="", append=TRUE )
-    		cat( 'description="',outfile,'"\n', file=outfile, sep="", append=TRUE )  	    
+    		if ( printHeader == FALSE ) {
+    		  cat( 'track type=wiggle_0 name="',outfile,'" ', file=outfile, sep="", append=TRUE )
+    		  cat( 'description="',outfile,'"\n', file=outfile, sep="", append=TRUE )  	    
+    		  printHeader <- TRUE
+    		}
   	    cat( 'variableStep chrom=',chr,' span=',span,'\n', file=outfile, sep="", append=TRUE )
      
         #for ( i in 1:length(bindata) )

--- a/man/mosaics-package.Rd
+++ b/man/mosaics-package.Rd
@@ -13,8 +13,8 @@ a statistical framework to analyze one-sample or two-sample ChIP-seq data.
 \tabular{ll}{
 Package: \tab mosaics\cr
 Type: \tab Package\cr
-Version: \tab 2.9.8\cr
-Date: \tab 2016-01-31\cr
+Version: \tab 2.9.9\cr
+Date: \tab 2016-03-15\cr
 License: \tab GPL (>= 2)\cr
 LazyLoad: \tab yes\cr
 }


### PR DESCRIPTION
bug fix: generateWig(): unnecessary lines in Wig files generated from
BAM files
